### PR TITLE
Update TypeScript compiler configuration settings

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "compilerOptions": {
+    "outDir": "./build",
+    "sourceMap": false,
+    "removeComments": true,
+    "declaration": true
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true, // Allow default imports from modules with no default export
+    "alwaysStrict": true, // Parse in strict mode and emit "use strict" for each source file
     "baseUrl": "./", // Base directory to resolve non-absolute module names
     "declaration": true, // Generate corresponding '.d.ts' file
     "emitDecoratorMetadata": true, // Emit design-type metadata for decorated declarations in source
@@ -21,7 +22,6 @@
     "noUncheckedIndexedAccess": true, // Include 'undefined' in index signature results
     "noUnusedLocals": true, // Report errors on unused local variables
     "noUnusedParameters": true, // Report errors on unused parameters in functions
-    "outDir": "./dist", // Redirect output structure to the directory
     "removeComments": true, // Do not emit comments to output
     "resolveJsonModule": true, // Include modules imported with '.json' extension
     "sourceMap": true, // Generates corresponding '.map' file
@@ -33,6 +33,8 @@
     "target": "ES2022", // Set the JavaScript language version for emitted JavaScript and include compatible library declarations
     "typeRoots": ["./node_modules/@types", "./types"], // List of folders to include type definitions from
     "types": ["node"], // Type declaration files to be included in compilation
-    "useUnknownInCatchVariables": true // Use 'unknown' type for catch clause variables instead of 'any'
-  }
+    "useUnknownInCatchVariables": true, // Use 'unknown' type for catch clause variables instead of 'any'
+  },
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "src/**/*.{spec,test}.ts"], // Specify a list of files to exclude from compilation
+  "include": ["src/**/*.ts"], // Specify a list of files to include in the compilation
 }


### PR DESCRIPTION
The configuration settings for the TypeScript compiler have been updated. We've added new compiler options in tsconfig.build.json, such as disabling sourceMaps, enabling comment removal, and setting the output directory as "./build". We've also adjusted settings in tsconfig.json, including setting the parsing to strict mode, removing the output directory path, and specifying the files to include and exclude during compilation.